### PR TITLE
Add custom endpoint and MAC generation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,20 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id AWS_SECRET_ACCESS_KEY=your-secr
 
 ## Configuration
 
-| **Environment Variable**                | **Default Value**  | **Required**                       | **Description**                                                                                        |
-|-----------------------------------------|--------------------|------------------------------------|--------------------------------------------------------------------------------------------------------|
-| `SQSD_QUEUE_REGION`                     |                    | yes                                | The region of the SQS queue.                                                                           |
-| `SQSD_QUEUE_URL`                        |                    | yes                                | The URL of the SQS queue.                                                                              |
-| `SQSD_QUEUE_MAX_MSGS`                   | `10`               | no                                 | Max number of messages a worker should try to receive from the SQS queue.                              |
-| `SQSD_QUEUE_WAIT_TIME`                  | `10`               | no                                 | Number of seconds for SQS to wait until a message is available in the queue before sending a response. |
-| `SQSD_HTTP_MAX_CONNS`                   | `50`               | no                                 | Maximum number of concurrent HTTP requests to make to SQSD_HTTP_URL.                                   |
-| `SQSD_HTTP_URL`                         |                    | yes                                | The URL of your service to make a request to.                                                          |
-| `SQSD_HTTP_CONTENT_TYPE`                |                    | no                                 | The value to send for the HTTP header `Content-Type` when making a request to your service.            |
-| `AWS_ENDPOINT`                          |                    | no                                 | Custom AWS Endpoint to use for testing locally with elasticMQ                                          |
-| `APP_API_SECRET_KEY`                    |                    | no                                 | Secret key used for generating HMAC SHA256 Hash to send to `SQSD_HTTP_URL`                             |
+|**Environment Variable**|**Default Value*|**Required**|**Description**|
+|-|-|-|-|
+|`SQSD_QUEUE_REGION`||yes|The region of the SQS queue.|
+|`SQSD_QUEUE_URL`||yes|The URL of the SQS queue.|
+|`SQSD_QUEUE_MAX_MSGS`|`10`|no|Max number of messages a worker should try to receive from the SQS queue.|
+|`SQSD_QUEUE_WAIT_TIME`|`10`|no|Number of seconds for SQS to wait until a message is available in the queue before sending a response.|
+|`SQSD_HTTP_MAX_CONNS`|`50`|no|Maximum number of concurrent HTTP requests to make to SQSD_HTTP_URL.|
+|`SQSD_HTTP_URL`||yes|The URL of your service to make a request to.|
+|`SQSD_HTTP_CONTENT_TYPE` ||no|The value to send for the HTTP header `Content-Type` when making a request to your service.|
+|`SQSD_AWS_ENDPOINT` ||no|Sets the AWS endpoint.|
+|`SQSD_HTTP_HMAC_HEADER`||no|The name of the HTTP header to send the HMAC hash with.|
+|`SQSD_HMAC_SECRET_KEY`||no|Secret key to use when generating HMAC hash send to `SQSD_HTTP_URL`.|
+
+HMAC hashes are generated using SHA-256.
 
 ## Todo
 - [ ] More Tests

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id AWS_SECRET_ACCESS_KEY=your-secr
 | `SQSD_HTTP_MAX_CONNS`                   | `50`               | no                                 | Maximum number of concurrent HTTP requests to make to SQSD_HTTP_URL.                                   |
 | `SQSD_HTTP_URL`                         |                    | yes                                | The URL of your service to make a request to.                                                          |
 | `SQSD_HTTP_CONTENT_TYPE`                |                    | no                                 | The value to send for the HTTP header `Content-Type` when making a request to your service.            |
+| `AWS_ENDPOINT`                          |                    | no                                 | Custom AWS Endpoint to use for testing locally with elasticMQ                                          |
+| `APP_API_SECRET_KEY`                    |                    | no                                 | Secret key used for generating HMAC SHA256 Hash to send to `SQSD_HTTP_URL`                             |
 
 ## Todo
 - [ ] More Tests

--- a/cmd/simplesqsd/simplesqsd.go
+++ b/cmd/simplesqsd/simplesqsd.go
@@ -14,6 +14,10 @@ import (
 )
 
 type config struct {
+	AWSEndpoint string
+
+	AppApiSecretKey []byte
+
 	QueueRegion      string
 	QueueURL         string
 	QueueMaxMessages int
@@ -26,6 +30,10 @@ type config struct {
 
 func main() {
 	c := &config{}
+
+	c.AWSEndpoint = os.Getenv("AWS_ENDPOINT")
+
+	c.AppApiSecretKey = []byte(os.Getenv("APP_API_SECRET_KEY"))
 
 	c.QueueRegion = os.Getenv("SQSD_QUEUE_REGION")
 	c.QueueURL = os.Getenv("SQSD_QUEUE_URL")
@@ -71,6 +79,10 @@ func main() {
 		WithRegion(c.QueueRegion).
 		WithHTTPClient(httpClient)
 
+	if c.AWSEndpoint != "" {
+		sqsConfig.WithEndpoint(c.AWSEndpoint)
+	}
+
 	sqsSvc := sqs.New(awsSess, sqsConfig)
 
 	// To workaround a kube2iam issue, expire credentials every minute.
@@ -85,6 +97,8 @@ func main() {
 		QueueURL:         c.QueueURL,
 		QueueMaxMessages: c.QueueMaxMessages,
 		QueueWaitTime:    c.QueueWaitTime,
+
+		SecretKey: c.AppApiSecretKey,
 
 		HTTPURL:         c.HTTPURL,
 		HTTPContentType: c.HTTPContentType,

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -53,7 +53,7 @@ func NewSupervisor(logger *log.Entry, sqs sqsiface.SQSAPI, httpClient httpClient
 		sqs:           sqs,
 		httpClient:    httpClient,
 		workerConfig:  config,
-		hmacSignature: fmt.Sprintf("POST %s", config.HTTPURL),
+		hmacSignature: fmt.Sprintf("POST %s\n", config.HTTPURL),
 	}
 }
 

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -155,7 +155,7 @@ func TestSupervisorHMAC(t *testing.T) {
 		body, _ := ioutil.ReadAll(r.Body)
 		r.Body.Close()
 
-		mac.Write([]byte(fmt.Sprintf("%s %s%s", r.Method, fmt.Sprintf("http://%s", r.Host), string(body))))
+		mac.Write([]byte(fmt.Sprintf("%s %s\n%s", r.Method, fmt.Sprintf("http://%s", r.Host), string(body))))
 		expectedMAC := hex.EncodeToString(mac.Sum(nil))
 
 		hmacSuccess = hmac.Equal([]byte(r.Header.Get(hmacHeader)), []byte(expectedMAC))


### PR DESCRIPTION
As we're using ElasticMQ for local testing I've added support for defining a custom AWS endpoint (just setting `SQSD_QUEUE_URL` didn't seem to be enough).

I've also added the ability to generate an HMAC SHA256 hash that will be sent to the defined `SQSD_HTTP_URL` which can be used for extra security in the internal communication between sqsd and your api endpoint.