### PR TITLE
Add support for a health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id AWS_SECRET_ACCESS_KEY=your-secr
 |`SQSD_AWS_ENDPOINT` ||no|Sets the AWS endpoint.|
 |`SQSD_HTTP_HMAC_HEADER`||no|The name of the HTTP header to send the HMAC hash with.|
 |`SQSD_HMAC_SECRET_KEY`||no|Secret key to use when generating HMAC hash send to `SQSD_HTTP_URL`.|
+|`SQSD_HTTP_HEALTH_PATH`||no|The path to a health check endpoint of your service. When provided, messages will not be processed until the health check returns a 200 for `HTTPHealthInterval` times |
+|`SQSD_HTTP_HEALTH_WAIT`|`5`|no|How often to wait before starting health checks|
+|`SQSD_HTTP_HEALTH_INTERVAL`|`5`|no|How often to wait between health checks|
+|`SQSD_HTTP_HEALTH_SUCCESS_COUNT`|`1`|no|How many successful health checks required in a row|
 
 ## HMAC
 

--- a/cmd/simplesqsd/simplesqsd.go
+++ b/cmd/simplesqsd/simplesqsd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -56,6 +57,17 @@ func main() {
 	}
 
 	log.SetFormatter(&log.JSONFormatter{})
+
+	logLevel := os.Getenv("LOG_LEVEL")
+	if len(logLevel) == 0 {
+		logLevel = "info"
+	}
+	if parsedLevel, err := log.ParseLevel(logLevel); err == nil {
+		log.SetLevel(parsedLevel)
+	} else {
+		log.Fatal(err)
+	}
+
 	logger := log.WithFields(log.Fields{
 		"queueRegion":  c.QueueRegion,
 		"queueUrl":     c.QueueURL,

--- a/cmd/simplesqsd/simplesqsd.go
+++ b/cmd/simplesqsd/simplesqsd.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -26,9 +27,15 @@ type config struct {
 	AWSEndpoint    string
 	HTTPHMACHeader string
 	HMACSecretKey  []byte
+
+	HTTPHealthPath        string
+	HTTPHealthWait        int
+	HTTPHealthInterval    int
+	HTTPHealthSucessCount int
 }
 
 func main() {
+
 	c := &config{}
 
 	c.QueueRegion = os.Getenv("SQSD_QUEUE_REGION")
@@ -39,6 +46,11 @@ func main() {
 	c.HTTPMaxConns = getEnvInt("SQSD_HTTP_MAX_CONNS", 50)
 	c.HTTPURL = os.Getenv("SQSD_HTTP_URL")
 	c.HTTPContentType = os.Getenv("SQSD_HTTP_CONTENT_TYPE")
+
+	c.HTTPHealthPath = os.Getenv("SQSD_HTTP_HEALTH_PATH")
+	c.HTTPHealthWait = getEnvInt("SQSD_HTTP_HEALTH_WAIT", 5)
+	c.HTTPHealthInterval = getEnvInt("SQSD_HTTP_HEALTH_INTERVAL", 5)
+	c.HTTPHealthSucessCount = getEnvInt("SQSD_HTTP_HEALTH_SUCCESS_COUNT", 1)
 
 	c.AWSEndpoint = os.Getenv("SQSD_AWS_ENDPOINT")
 	c.HTTPHMACHeader = os.Getenv("SQSD_HTTP_HMAC_HEADER")
@@ -74,6 +86,27 @@ func main() {
 		"httpMaxConns": c.HTTPMaxConns,
 		"httpPath":     c.HTTPURL,
 	})
+
+	if len(c.HTTPHealthPath) != 0 {
+		numSuccesses := 0
+		healthURL := fmt.Sprintf("%s%s", c.HTTPURL, c.HTTPHealthPath)
+		log.Infof("Waiting %d seconds before staring health check at '%s'", c.HTTPHealthWait, healthURL)
+		time.Sleep(time.Duration(c.HTTPHealthWait) * time.Second)
+		for {
+			if resp, err := http.Get(healthURL); err == nil {
+				log.Infof("%#v", resp)
+				if numSuccesses == c.HTTPHealthSucessCount {
+					break
+				} else {
+					numSuccesses++
+				}
+			} else {
+				log.Debugf("Health check failed: %s. Waiting for %d seconds before next attempt", err, c.HTTPHealthInterval)
+				time.Sleep(time.Duration(c.HTTPHealthInterval) * time.Second)
+			}
+		}
+		log.Info("Health check succeeded. Starting message processing")
+	}
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{


### PR DESCRIPTION
I have a downstream http server which takes a while to start up. This allows me to make sure no messages get processed before the server is ready.