### PR TITLE
Can Skip SSL Verify on service Url

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id AWS_SECRET_ACCESS_KEY=your-secr
 |`SQSD_HTTP_HEALTH_INTERVAL`|`5`|no|How often to wait between health checks|
 |`SQSD_HTTP_HEALTH_SUCCESS_COUNT`|`1`|no|How many successful health checks required in a row|
 |`SQSD_HTTP_TIMEOUT`|`30`|no|Number of seconds to wait for a response from the worker|
+|`SQSD_HTTP_SSL_VERIFY`|`true`|no|Enable SSL Verification on the URL of your service to make a request to (if you're using self-signed certificate)|
 
 ## HMAC
 

--- a/cmd/simplesqsd/simplesqsd.go
+++ b/cmd/simplesqsd/simplesqsd.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -23,7 +25,7 @@ type config struct {
 	HTTPMaxConns    int
 	HTTPURL         string
 	HTTPContentType string
-	HTTPTimeout		int
+	HTTPTimeout     int
 
 	AWSEndpoint    string
 	HTTPHMACHeader string
@@ -33,6 +35,8 @@ type config struct {
 	HTTPHealthWait        int
 	HTTPHealthInterval    int
 	HTTPHealthSucessCount int
+
+	SSLVerify bool
 }
 
 func main() {
@@ -57,6 +61,8 @@ func main() {
 	c.AWSEndpoint = os.Getenv("SQSD_AWS_ENDPOINT")
 	c.HTTPHMACHeader = os.Getenv("SQSD_HTTP_HMAC_HEADER")
 	c.HMACSecretKey = []byte(os.Getenv("SQSD_HMAC_SECRET_KEY"))
+
+	c.SSLVerify = getenvBool("SQSD_HTTP_SSL_VERIFY", true)
 
 	if len(c.QueueRegion) == 0 {
 		log.Fatal("SQSD_QUEUE_REGION cannot be empty")
@@ -146,7 +152,10 @@ func main() {
 		Transport: &http.Transport{
 			MaxIdleConns:        c.HTTPMaxConns,
 			MaxIdleConnsPerHost: c.HTTPMaxConns,
-
+			TLSClientConfig: &tls.Config{
+				MaxVersion:         tls.VersionTLS11,
+				InsecureSkipVerify: !c.SSLVerify,
+			},
 		},
 		Timeout: time.Duration(c.HTTPTimeout) * time.Second,
 	}
@@ -163,4 +172,26 @@ func getEnvInt(key string, def int) int {
 	}
 
 	return val
+}
+
+var ErrEnvVarEmpty = errors.New("getenv: environment variable empty")
+
+func getenvStr(key string) (string, error) {
+	v := os.Getenv(key)
+	if len(v) == 0 {
+		return v, ErrEnvVarEmpty
+	}
+	return v, nil
+}
+
+func getenvBool(key string, def bool) bool {
+	s, err := getenvStr(key)
+	if err != nil {
+		return def
+	}
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return def
+	}
+	return v
 }


### PR DESCRIPTION
Implementing feature on ref #9. It allow user to skip SSL verification when POSTing to the endpoint. Useful when working on development environment with autogenerated certificats.
