### PR TITLE
Log on message successfully processed

### DIFF
--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -143,6 +143,8 @@ func (s *Supervisor) worker() {
 				Id:            msg.MessageId,
 				ReceiptHandle: msg.ReceiptHandle,
 			})
+
+			s.logger.Debugf("Message %s successfully processed", *msg.MessageId)
 		}
 
 		if len(deleteEntries) > 0 {


### PR DESCRIPTION
I add a log when a message has been successfully processed, it can be useful in development. Only visible on LOG_LEVEL=debug