### PR TITLE
Adds configurable timeout to sqs http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id AWS_SECRET_ACCESS_KEY=your-secr
 |`SQSD_HTTP_HEALTH_WAIT`|`5`|no|How long to wait before starting health checks|
 |`SQSD_HTTP_HEALTH_INTERVAL`|`5`|no|How often to wait between health checks|
 |`SQSD_HTTP_HEALTH_SUCCESS_COUNT`|`1`|no|How many successful health checks required in a row|
-|`SQSD_HTTP_TIMEOUT`|`30`|no|Number of seconds to wait for a response from the worker|
+|`SQSD_HTTP_TIMEOUT`|`5`|no|Number of seconds to wait for a response from the worker|
+|`SQSD_SQS_HTTP_TIMEOUT`|`5`|no|Number of seconds to wait for a response from sqs|
 |`SQSD_HTTP_SSL_VERIFY`|`true`|no|Enable SSL Verification on the URL of your service to make a request to (if you're using self-signed certificate)|
 
 ## HMAC

--- a/cmd/simplesqsd/simplesqsd.go
+++ b/cmd/simplesqsd/simplesqsd.go
@@ -36,7 +36,8 @@ type config struct {
 	HTTPHealthInterval    int
 	HTTPHealthSucessCount int
 
-	SSLVerify bool
+	SQSHTTPTimeout int
+	SSLVerify      bool
 }
 
 func main() {
@@ -56,12 +57,13 @@ func main() {
 	c.HTTPHealthWait = getEnvInt("SQSD_HTTP_HEALTH_WAIT", 5)
 	c.HTTPHealthInterval = getEnvInt("SQSD_HTTP_HEALTH_INTERVAL", 5)
 	c.HTTPHealthSucessCount = getEnvInt("SQSD_HTTP_HEALTH_SUCCESS_COUNT", 1)
-	c.HTTPTimeout = getEnvInt("SQSD_HTTP_TIMEOUT", 30)
+	c.HTTPTimeout = getEnvInt("SQSD_HTTP_TIMEOUT", 5)
 
 	c.AWSEndpoint = os.Getenv("SQSD_AWS_ENDPOINT")
 	c.HTTPHMACHeader = os.Getenv("SQSD_HTTP_HMAC_HEADER")
 	c.HMACSecretKey = []byte(os.Getenv("SQSD_HMAC_SECRET_KEY"))
 
+	c.SQSHTTPTimeout = getEnvInt("SQSD_SQS_HTTP_TIMEOUT", 5)
 	c.SSLVerify = getenvBool("SQSD_HTTP_SSL_VERIFY", true)
 
 	if len(c.QueueRegion) == 0 {
@@ -121,6 +123,7 @@ func main() {
 	}))
 
 	sqsHttpClient := &http.Client{
+		Timeout: time.Duration(c.SQSHTTPTimeout) * time.Second,
 		Transport: &http.Transport{
 			MaxIdleConns:        c.HTTPMaxConns,
 			MaxIdleConnsPerHost: c.HTTPMaxConns,


### PR DESCRIPTION
To prevent hanging connections when communicating with SQS we need to add a timeout to the http client. I went with 30 seconds since that is the timeout on the worker.