### PR TITLE
add range and info about WaitTimeSeconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id AWS_SECRET_ACCESS_KEY=your-secr
 |`SQSD_QUEUE_REGION`||yes|The region of the SQS queue.|
 |`SQSD_QUEUE_URL`||yes|The URL of the SQS queue.|
 |`SQSD_QUEUE_MAX_MSGS`|`10`|no|Max number of messages a worker should try to receive from the SQS queue.|
-|`SQSD_QUEUE_WAIT_TIME`|`10`|no|Number of seconds to wait between polling sqs. Setting this to `0` disables long polling. Maximum of `20` seconds.|
+|`SQSD_QUEUE_WAIT_TIME`|`10`|no|The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. Setting this to `0` disables long polling. Maximum of `20` seconds.|
 |`SQSD_HTTP_MAX_CONNS`|`25`|no|Maximum number of concurrent HTTP requests to make to SQSD_HTTP_URL.|
 |`SQSD_HTTP_URL`||yes|The URL of your service to make a request to.|
 |`SQSD_HTTP_CONTENT_TYPE` ||no|The value to send for the HTTP header `Content-Type` when making a request to your service.|

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id AWS_SECRET_ACCESS_KEY=your-secr
 |`SQSD_QUEUE_REGION`||yes|The region of the SQS queue.|
 |`SQSD_QUEUE_URL`||yes|The URL of the SQS queue.|
 |`SQSD_QUEUE_MAX_MSGS`|`10`|no|Max number of messages a worker should try to receive from the SQS queue.|
-|`SQSD_QUEUE_WAIT_TIME`|`10`|no|Number of seconds for SQS to wait until a message is available in the queue before sending a response. Setting this to `0` disables long polling. Maximum of `20` seconds.|
+|`SQSD_QUEUE_WAIT_TIME`|`10`|no|Number of seconds to wait between polling sqs. Setting this to `0` disables long polling. Maximum of `20` seconds.|
 |`SQSD_HTTP_MAX_CONNS`|`25`|no|Maximum number of concurrent HTTP requests to make to SQSD_HTTP_URL.|
 |`SQSD_HTTP_URL`||yes|The URL of your service to make a request to.|
 |`SQSD_HTTP_CONTENT_TYPE` ||no|The value to send for the HTTP header `Content-Type` when making a request to your service.|

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id AWS_SECRET_ACCESS_KEY=your-secr
 |`SQSD_QUEUE_REGION`||yes|The region of the SQS queue.|
 |`SQSD_QUEUE_URL`||yes|The URL of the SQS queue.|
 |`SQSD_QUEUE_MAX_MSGS`|`10`|no|Max number of messages a worker should try to receive from the SQS queue.|
-|`SQSD_QUEUE_WAIT_TIME`|`10`|no|Number of seconds for SQS to wait until a message is available in the queue before sending a response.|
+|`SQSD_QUEUE_WAIT_TIME`|`10`|no|Number of seconds for SQS to wait until a message is available in the queue before sending a response. Setting this to `0` disables long polling. Maximum of `20` seconds.|
 |`SQSD_HTTP_MAX_CONNS`|`25`|no|Maximum number of concurrent HTTP requests to make to SQSD_HTTP_URL.|
 |`SQSD_HTTP_URL`||yes|The URL of your service to make a request to.|
 |`SQSD_HTTP_CONTENT_TYPE` ||no|The value to send for the HTTP header `Content-Type` when making a request to your service.|


### PR DESCRIPTION
`SQSD_QUEUE_WAIT_TIME` controls the parameter `WaitTimeSeconds`, which controls long polling. It has a max value of 20 seconds, so we should document that.

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html