### PR TITLE
Sqsd http authorization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id -e AWS_SECRET_ACCESS_KEY=your-s
 |`SQSD_HTTP_TIMEOUT`|`15`|no|Number of seconds to wait for a response from the worker|
 |`SQSD_SQS_HTTP_TIMEOUT`|`15`|no|Number of seconds to wait for a response from sqs|
 |`SQSD_HTTP_SSL_VERIFY`|`true`|no|Enable SSL Verification on the URL of your service to make a request to (if you're using self-signed certificate)|
-
+|`SQSD_HTTP_AUTHORIZATION_HEADER`||no|A simple feature to add a jwt/simple token to Authorization header for basic auth on SQSD_HTTP_URL |
 ## HMAC
 
 *Optionally* (when SQSD_HTTP_HMAC_HEADER and SQSD_HMAC_SECRET_KEY are set), HMAC hashes are generated using SHA-256 with the signature made up of the following:

--- a/cmd/simplesqsd/simplesqsd.go
+++ b/cmd/simplesqsd/simplesqsd.go
@@ -29,6 +29,7 @@ type config struct {
 
 	AWSEndpoint    string
 	HTTPHMACHeader string
+	HTTPAUTHORIZATIONHeader string
 	HMACSecretKey  []byte
 
 	HTTPHealthPath        string
@@ -61,6 +62,7 @@ func main() {
 
 	c.AWSEndpoint = os.Getenv("SQSD_AWS_ENDPOINT")
 	c.HTTPHMACHeader = os.Getenv("SQSD_HTTP_HMAC_HEADER")
+	c.HTTPAUTHORIZATIONHeader = os.Getenv("SQSD_HTTP_AUTHORIZATION_HEADER")
 	c.HMACSecretKey = []byte(os.Getenv("SQSD_HMAC_SECRET_KEY"))
 
 	c.SQSHTTPTimeout = getEnvInt("SQSD_SQS_HTTP_TIMEOUT", 15)
@@ -147,6 +149,8 @@ func main() {
 		HTTPURL:         c.HTTPURL,
 		HTTPContentType: c.HTTPContentType,
 
+		HTTPAUTHORIZATIONHeader: c.HTTPAUTHORIZATIONHeader,
+		
 		HTTPHMACHeader: c.HTTPHMACHeader,
 		HMACSecretKey:  c.HMACSecretKey,
 	}

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -41,6 +41,8 @@ type WorkerConfig struct {
 	HTTPURL         string
 	HTTPContentType string
 
+    HTTPAUTHORIZATIONHeader string
+
 	HTTPHMACHeader string
 	HMACSecretKey  []byte
 }
@@ -189,6 +191,10 @@ func (s *Supervisor) httpRequest(msg *sqs.Message) (*http.Response, error) {
 		}
 
 		req.Header.Set(s.workerConfig.HTTPHMACHeader, hmac)
+	}
+
+	if len(s.workerConfig.HTTPAUTHORIZATIONHeader) > 0 {
+		req.Header.Set("Authorization", s.workerConfig.HTTPAUTHORIZATIONHeader)
 	}
 
 	if len(s.workerConfig.HTTPContentType) > 0 {


### PR DESCRIPTION
A simple update to allow a Authorization header for a basic API authentication.

Obviously would be some kinda of static key.