### PR TITLE
new env SQSD_HTTP_AUTHORIZATION_HEADER_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id -e AWS_SECRET_ACCESS_KEY=your-s
 |`SQSD_SQS_HTTP_TIMEOUT`|`15`|no|Number of seconds to wait for a response from sqs|
 |`SQSD_HTTP_SSL_VERIFY`|`true`|no|Enable SSL Verification on the URL of your service to make a request to (if you're using self-signed certificate)|
 |`SQSD_HTTP_AUTHORIZATION_HEADER`||no|A simple feature to add a jwt/simple token to Authorization header for basic auth on SQSD_HTTP_URL |
+|`SQSD_HTTP_AUTHORIZATION_HEADER_NAME`||no|override the http header name (defaults to Authorization) in SQSD_HTTP_AUTHORIZATION_HEADER |
 ## HMAC
 
 *Optionally* (when SQSD_HTTP_HMAC_HEADER and SQSD_HMAC_SECRET_KEY are set), HMAC hashes are generated using SHA-256 with the signature made up of the following:

--- a/cmd/simplesqsd/simplesqsd.go
+++ b/cmd/simplesqsd/simplesqsd.go
@@ -30,6 +30,7 @@ type config struct {
 	AWSEndpoint    string
 	HTTPHMACHeader string
 	HTTPAUTHORIZATIONHeader string
+	HTTPAUTHORIZATIONHeaderName string
 	HMACSecretKey  []byte
 
 	HTTPHealthPath        string
@@ -63,6 +64,7 @@ func main() {
 	c.AWSEndpoint = os.Getenv("SQSD_AWS_ENDPOINT")
 	c.HTTPHMACHeader = os.Getenv("SQSD_HTTP_HMAC_HEADER")
 	c.HTTPAUTHORIZATIONHeader = os.Getenv("SQSD_HTTP_AUTHORIZATION_HEADER")
+	c.HTTPAUTHORIZATIONHeaderName = os.Getenv("SQSD_HTTP_AUTHORIZATION_HEADER_NAME")
 	c.HMACSecretKey = []byte(os.Getenv("SQSD_HMAC_SECRET_KEY"))
 
 	c.SQSHTTPTimeout = getEnvInt("SQSD_SQS_HTTP_TIMEOUT", 15)
@@ -150,6 +152,7 @@ func main() {
 		HTTPContentType: c.HTTPContentType,
 
 		HTTPAUTHORIZATIONHeader: c.HTTPAUTHORIZATIONHeader,
+		HTTPAUTHORIZATIONHeaderName: c.HTTPAUTHORIZATIONHeaderName,
 		
 		HTTPHMACHeader: c.HTTPHMACHeader,
 		HMACSecretKey:  c.HMACSecretKey,

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -42,6 +42,7 @@ type WorkerConfig struct {
 	HTTPContentType string
 
     HTTPAUTHORIZATIONHeader string
+	HTTPAUTHORIZATIONHeaderName string
 
 	HTTPHMACHeader string
 	HMACSecretKey  []byte
@@ -194,7 +195,11 @@ func (s *Supervisor) httpRequest(msg *sqs.Message) (*http.Response, error) {
 	}
 
 	if len(s.workerConfig.HTTPAUTHORIZATIONHeader) > 0 {
-		req.Header.Set("Authorization", s.workerConfig.HTTPAUTHORIZATIONHeader)
+		headerName := s.workerConfig.HTTPAUTHORIZATIONHeaderName
+		if len(headerName) == 0 {
+			headerName = "Authorization"
+		}
+		req.Header.Set(headerName, s.workerConfig.HTTPAUTHORIZATIONHeader)
 	}
 
 	if len(s.workerConfig.HTTPContentType) > 0 {


### PR DESCRIPTION
Builds on fterrag/simple-sqsd#24

Allows customizing the auth header name to something other than `Authorization`