### PR TITLE
Cron support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id -e AWS_SECRET_ACCESS_KEY=your-s
 |`SQSD_HTTP_SSL_VERIFY`|`true`|no|Enable SSL Verification on the URL of your service to make a request to (if you're using self-signed certificate)|
 |`SQSD_HTTP_AUTHORIZATION_HEADER`||no|A simple feature to add a jwt/simple token to Authorization header for basic auth on SQSD_HTTP_URL |
 |`SQSD_HTTP_AUTHORIZATION_HEADER_NAME`||no|override the http header name (defaults to Authorization) in SQSD_HTTP_AUTHORIZATION_HEADER |
+|`SQSD_CRON_FILE`||no|The elastic beanstalk cron.yaml file to load|
+|`SQSD_CRON_ENDPOINT`|`SQSD_HTTP_URL` without path/query|yes if SQSD_CRON_FILE|The base URL to call (e.g. http://localhost:3000). cron.yaml url will be appended to this|
+|`SQSD_CRON_TIMEOUT`|`15`|no|Duration (in seconds) To wait for the cron endpoint to response|
+
 ## HMAC
 
 *Optionally* (when SQSD_HTTP_HMAC_HEADER and SQSD_HMAC_SECRET_KEY are set), HMAC hashes are generated using SHA-256 with the signature made up of the following:

--- a/cmd/simplesqsd/simplesqsd.go
+++ b/cmd/simplesqsd/simplesqsd.go
@@ -43,9 +43,9 @@ type config struct {
 	SQSHTTPTimeout int
 	SSLVerify      bool
 
-	CronFile          string
-	CronEndPoint      string
-	CronWarnThreshold int
+	CronFile     string
+	CronEndPoint string
+	CronTimeout  int
 }
 
 func main() {
@@ -78,7 +78,7 @@ func main() {
 
 	c.CronFile = os.Getenv("SQSD_CRON_FILE")
 	c.CronEndPoint = os.Getenv("SQSD_CRON_ENDPOINT")
-	c.CronWarnThreshold = getEnvInt("SQSD_CRON_WARN_AFTER", 120)
+	c.CronTimeout = getEnvInt("SQSD_CRON_TIMEOUT", 15)
 
 	if len(c.QueueRegion) == 0 {
 		log.Fatal("SQSD_QUEUE_REGION cannot be empty")
@@ -193,9 +193,9 @@ func main() {
 		log.Fatal("You need to specify SQSD_CRON_URL")
 	}
 	cronDaemon := cron_worker.New(&cron_worker.Config{
-		File:          c.CronFile,
-		EndPoint:      c.CronEndPoint,
-		WarnThreshold: time.Duration(c.CronWarnThreshold) * time.Second,
+		File:     c.CronFile,
+		EndPoint: c.CronEndPoint,
+		Timeout:  time.Duration(c.CronTimeout) * time.Second,
 	})
 	if nil != cronDaemon {
 		go cronDaemon.Run()

--- a/cron_worker/worker.go
+++ b/cron_worker/worker.go
@@ -1,0 +1,182 @@
+package cron_worker
+
+import (
+	"errors"
+	"github.com/robfig/cron/v3"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+type (
+	Config struct {
+		File          string
+		EndPoint      string
+		WarnThreshold time.Duration
+	}
+	Worker struct {
+		config  *Config
+		crontab *sqsCron
+
+		cron *cron.Cron
+	}
+	sqsCronItem struct {
+		Name        string `yaml:"name"`
+		Url         string `yaml:"url"`
+		Schedule    string `yaml:"schedule"`
+		cronEntryId cron.EntryID
+	}
+	sqsCron struct {
+		Version int `yaml:"version"`
+		Cron    []sqsCronItem
+	}
+)
+
+func New(c *Config) *Worker {
+	if "" == c.File {
+		log.Info("No Cron File Supplied")
+		return nil
+	}
+
+	wkr := Worker{
+		config:  c,
+		crontab: nil,
+	}
+	wkr.loadCronTab()
+
+	return &wkr
+}
+
+func (w *Worker) Run() {
+	if nil == w.cron {
+		log.Errorf("Cannot run cron")
+		return
+	}
+	w.cron.Start()
+	for _, entry := range w.crontab.Cron {
+		log.
+			WithField("what", "cron").
+			WithField("name", entry.Name).
+			WithField("next", w.cron.Entry(entry.cronEntryId).Next).
+			Debug("Next Occurrence")
+	}
+
+	// TODO: wait on w.config.File changes and reload the crontab
+}
+
+func (w *Worker) Stop() {
+	w.cron.Stop()
+}
+
+// loadCronTab is the parent method that reads, parses and then loads the crontab
+func (w *Worker) loadCronTab() {
+	contents, err := w.readCronTab(w.config.File)
+	if nil != err {
+		log.WithError(err).Error("Failed to load crontab")
+		return
+	}
+
+	if err = w.parseCronTab(contents); nil != err {
+		log.WithError(err).Error("Failed to parse crontab")
+		return
+	}
+
+	// log some info about our crontab
+	log.
+		WithField("file", w.config.File).
+		WithField("version", w.crontab.Version).
+		WithField("num-entries", len(w.crontab.Cron)).
+		Info("EBS Crontab Info")
+
+	if err = w.loadCronEntries(); nil != err {
+		log.WithError(err).Error("Failed to start crontab")
+		return
+	}
+}
+
+func (w *Worker) readCronTab(path string) ([]byte, error) {
+	fh, err := os.Open(path)
+	if nil != err {
+		return nil, err
+	}
+
+	return io.ReadAll(fh)
+}
+
+func (w *Worker) parseCronTab(contents []byte) error {
+	crontab := sqsCron{}
+
+	err := yaml.Unmarshal(contents, &crontab)
+	if nil != err {
+		return err
+	}
+
+	w.crontab = &crontab
+	return nil
+}
+
+func (w *Worker) loadCronEntries() error {
+	if nil == w.crontab {
+		return errors.New("please parse a crontab before loading it")
+	}
+
+	w.cron = cron.New()
+
+	for idx, entry := range w.crontab.Cron {
+		log.WithField("entry", entry.Name).Debug("Adding Cron Entry")
+		entryId, err := w.cron.AddFunc(entry.Schedule, w.makeCronRequestFunc(entry))
+		if err != nil {
+			log.
+				WithField("what", "cron").
+				WithError(err).
+				WithField("entry", entry.Name).
+				Error("Failed to load cron entry")
+			continue
+		}
+		w.crontab.Cron[idx].cronEntryId = entryId
+	}
+
+	return nil
+}
+
+func (w *Worker) makeCronRequestFunc(entry sqsCronItem) func() {
+	cronUrl := w.config.EndPoint + entry.Url
+	return func() {
+		t1 := time.Now()
+		rqLog := log.
+			WithField("what", "cron").
+			WithField("entry", entry.Name).
+			WithField("url", cronUrl).
+			WithField("start", t1)
+
+		rqLog.Debug("Requesting Cron URL")
+
+		resp, err := http.Post(cronUrl, "application/json", nil)
+		if err != nil {
+			rqLog.
+				WithError(err).
+				Error("Failed Requesting Endpoint")
+			return
+		}
+		rqLog.WithField("http-status", resp.StatusCode)
+
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			rqLog.
+				Error("Requesting cron endpoint resulted in non 2XX Status Code")
+		}
+		t2 := time.Now()
+
+		dur := t2.Sub(t1)
+
+		rqLog.WithField("duration", dur.String())
+
+		if w.config.WarnThreshold > 0 && dur > w.config.WarnThreshold {
+			rqLog.Warn("Cron Job Time Taken Exceeded Threshold")
+		} else {
+			rqLog.Info("Cron Success")
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/aws/aws-sdk-go v1.36.18
 	github.com/onsi/ginkgo v1.15.1 // indirect
 	github.com/onsi/gomega v1.11.0 // indirect
+	github.com/robfig/cron/v3 v3.0.0 // indirect
 	github.com/sirupsen/logrus v1.0.4
 	github.com/stretchr/testify v1.2.2
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/aws/aws-sdk-go v1.36.18
+	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/onsi/ginkgo v1.15.1 // indirect
 	github.com/onsi/gomega v1.11.0 // indirect
 	github.com/robfig/cron/v3 v3.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
+github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -71,6 +73,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091 h1:DMyOG0U+gKfu8JZzg2UQe9MeaC1X+xQWlAKcRnjxjCw=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/onsi/gomega v1.11.0/go.mod h1:azGKhqFUon9Vuj0YmTfLSmx0FUwqXYSTl5re8lQ
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
+github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/sirupsen/logrus v1.0.4 h1:gzbtLsZC3Ic5PptoRG+kQj4L60qjK7H7XszrU163JNQ=
 github.com/sirupsen/logrus v1.0.4/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Hi There,

Elastic Beanstalk workers have support for a cron yaml file

https://aws.amazon.com/premiumsupport/knowledge-center/elastic-beanstalk-cron-job-worker-tier/

This PR has support for reading the file (and fsnotify for when it changes), loading the cron and running the specified cron HTTP requests.

I have used 3 additional environment variables and documented them in the README.md

(p.s. I have been using simple-sqsd daily for years and love it!)