### PR TITLE
Add new env SQSD_HTTP_USER_AGENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ $ docker run -e AWS_ACCESS_KEY_ID=your-access-id -e AWS_SECRET_ACCESS_KEY=your-s
 |`SQSD_HTTP_MAX_CONNS`|`25`|no|Maximum number of concurrent HTTP requests to make to SQSD_HTTP_URL.|
 |`SQSD_HTTP_URL`||yes|The URL of your service to make a request to.|
 |`SQSD_HTTP_CONTENT_TYPE` ||no|The value to send for the HTTP header `Content-Type` when making a request to your service.|
+|`SQSD_HTTP_USER_AGENT`||no|The value to send for the HTTP header `User-Agent` when making a request to your service.|
 |`SQSD_AWS_ENDPOINT` ||no|Sets the AWS endpoint.|
 |`SQSD_HTTP_HMAC_HEADER`||no|The name of the HTTP header to send the HMAC hash with.|
 |`SQSD_HMAC_SECRET_KEY`||no|Secret key to use when generating HMAC hash send to `SQSD_HTTP_URL`.|

--- a/cmd/simplesqsd/simplesqsd.go
+++ b/cmd/simplesqsd/simplesqsd.go
@@ -46,6 +46,8 @@ type config struct {
 	CronFile     string
 	CronEndPoint string
 	CronTimeout  int
+
+	UserAgent string
 }
 
 func main() {
@@ -60,6 +62,7 @@ func main() {
 	c.HTTPMaxConns = getEnvInt("SQSD_HTTP_MAX_CONNS", 25)
 	c.HTTPURL = os.Getenv("SQSD_HTTP_URL")
 	c.HTTPContentType = os.Getenv("SQSD_HTTP_CONTENT_TYPE")
+	c.UserAgent = os.Getenv("SQSD_HTTP_USER_AGENT")
 
 	c.HTTPHealthPath = os.Getenv("SQSD_HTTP_HEALTH_PATH")
 	c.HTTPHealthWait = getEnvInt("SQSD_HTTP_HEALTH_WAIT", 5)
@@ -79,6 +82,7 @@ func main() {
 	c.CronFile = os.Getenv("SQSD_CRON_FILE")
 	c.CronEndPoint = os.Getenv("SQSD_CRON_ENDPOINT")
 	c.CronTimeout = getEnvInt("SQSD_CRON_TIMEOUT", 15)
+
 
 	if len(c.QueueRegion) == 0 {
 		log.Fatal("SQSD_QUEUE_REGION cannot be empty")
@@ -166,6 +170,8 @@ func main() {
 
 		HTTPHMACHeader: c.HTTPHMACHeader,
 		HMACSecretKey:  c.HMACSecretKey,
+
+		UserAgent: c.UserAgent,
 	}
 
 	httpClient := &http.Client{

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -46,6 +46,8 @@ type WorkerConfig struct {
 
 	HTTPHMACHeader string
 	HMACSecretKey  []byte
+
+	UserAgent string
 }
 
 type httpClient interface {
@@ -204,6 +206,10 @@ func (s *Supervisor) httpRequest(msg *sqs.Message) (*http.Response, error) {
 
 	if len(s.workerConfig.HTTPContentType) > 0 {
 		req.Header.Set("Content-Type", s.workerConfig.HTTPContentType)
+	}
+
+	if len(s.workerConfig.UserAgent) > 0 {
+		req.Header.Set("User-Agent", s.workerConfig.UserAgent)
 	}
 
 	res, err := s.httpClient.Do(req)


### PR DESCRIPTION
Add a new env `SQSD_HTTP_USER_AGENT` to be able to set user agent on requests. Required to use this simple-sqsd with Active Elastic Job since that project [checks the user agent on inbound requests](https://github.com/active-elastic-job/active-elastic-job/blob/master/lib/active_elastic_job/rack/sqs_message_consumer.rb#L39)